### PR TITLE
Updated nltk requirement for python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nltk
+nltk==3.4.5
 scikit-learn
 beautifulsoup4
 numpy


### PR DESCRIPTION
Without this pip installs the latest version which is not supported by python 2.7